### PR TITLE
Invalid version format in package.json

### DIFF
--- a/Assets/NaninovelInventory/package.json
+++ b/Assets/NaninovelInventory/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.elringus.naninovelinventory",
-    "version": "1.1",
+    "version": "1.1.0",
     "displayName": "Naninovel Inventory",
     "description": "Inventory system extension for Naninovel visual novel engine",
     "unity": "2019.4",


### PR DESCRIPTION
Unity 22.3.11f1.

The package can't be installed via git due to version format. It have to be SemVer

Error:
```
[Package Manager Window] Error adding package: https://github.com/Naninovel/Inventory.git?path=Assets/NaninovelInventory.
Unable to add package [https://github.com/Naninovel/Inventory.git?path=Assets/NaninovelInventory]:
  Manifest [UnityProject\Library\PackageCache\com.elringus.naninovelinventory@c1b911995a\package.json] is invalid:
    Version '1.1' is invalid. Expected a 'SemVer' compatible value.
UnityEditor.EditorApplication:Internal_CallUpdateFunctions ()
```

So I added missing minor version to make the version in package look like semver